### PR TITLE
Fix issue where poDoctrineMigration overrides first import

### DIFF
--- a/lib/Doctrine/Migration.php
+++ b/lib/Doctrine/Migration.php
@@ -133,6 +133,7 @@ class Doctrine_Migration
 
         $classesToLoad = array();
         $classes = get_declared_classes();
+        array_push($classes, 'poDoctrineMigration');
         foreach ((array) $directory as $dir) {
             $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir),
                 RecursiveIteratorIterator::LEAVES_ONLY);


### PR DESCRIPTION
When the first require is made (line 149 below), two classes are added to the declared list - the class defined in the migration file AND "poDoctrineMigration".

![Migration php — paypa-stack  SSH: remote-workspace  2022-09-27 11-24-38](https://user-images.githubusercontent.com/5975946/192410790-ee81541a-e34f-42bc-90e7-62136a8b23c9.png)

When the `end` function is called, sometimes we pick off the wrong newly generated class and assign the migration the name "poDoctrineMigration". 

![Migration php — paypa-stack  SSH: remote-workspace  2022-09-27 11-24-48](https://user-images.githubusercontent.com/5975946/192410795-1264ca4b-90f6-4dc2-adf6-e73ae8964186.png)

