### PR TITLE
Refactored around deprecated each function

### DIFF
--- a/lib/Doctrine/Connection/UnitOfWork.php
+++ b/lib/Doctrine/Connection/UnitOfWork.php
@@ -101,7 +101,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
                     foreach ($record->getPendingDeletes() as $pendingDelete) {
                         $pendingDelete->delete();
                     }
-                
+
                     foreach ($record->getPendingUnlinks() as $alias => $ids) {
                         if ($ids === false) {
                             $record->unlinkInDb($alias, array());
@@ -237,7 +237,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
                 $params = array();
                 $columnNames = array();
                 foreach ($identifierMaps as $idMap) {
-                    while (list($fieldName, $value) = each($idMap)) {
+                    foreach ($idMap as $fieldName => $value) {
                         $params[] = $value;
                         $columnNames[] = $table->getColumnName($fieldName);
                     }
@@ -376,7 +376,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
 
         return $saveLater;
     }
-    
+
     /**
      * saveRelatedLocalKeys
      * saves all related (through LocalKey) records to $record
@@ -391,7 +391,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
 
         foreach ($record->getReferences() as $k => $v) {
             $rel = $record->getTable()->getRelation($k);
-            
+
             $local = $rel->getLocal();
             $foreign = $rel->getForeign();
 
@@ -408,7 +408,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
                     if ( ! empty($id)) {
                         foreach ((array) $rel->getLocal() as $k => $columnName) {
                             $field = $record->getTable()->getFieldName($columnName);
-                            
+
                             if (isset($id[$k]) && $id[$k] && $record->getTable()->hasField($field)) {
                                 $record->set($field, $id[$k]);
                             }
@@ -548,11 +548,11 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
      * Inserts a record into database.
      *
      * This method inserts a transient record in the database, and adds it
-     * to the identity map of its correspondent table. It proxies to @see 
+     * to the identity map of its correspondent table. It proxies to @see
      * processSingleInsert(), trigger insert hooks and validation of data
      * if required.
      *
-     * @param Doctrine_Record $record   
+     * @param Doctrine_Record $record
      * @return boolean                  false if record is not valid
      */
     public function insert(Doctrine_Record $record)
@@ -584,7 +584,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
     /**
      * Replaces a record into database.
      *
-     * @param Doctrine_Record $record   
+     * @param Doctrine_Record $record
      * @return boolean                  false if record is not valid
      */
     public function replace(Doctrine_Record $record)
@@ -600,7 +600,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
 
                 $table = $record->getTable();
                 $identifier = (array) $table->getIdentifier();
-                $data = $record->getPrepared();       
+                $data = $record->getPrepared();
 
                 foreach ($data as $key  => $value) {
                     if ($value instanceof Doctrine_Expression) {
@@ -625,9 +625,9 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
     /**
      * Inserts a transient record in its table.
      *
-     * This method inserts the data of a single record in its assigned table, 
+     * This method inserts the data of a single record in its assigned table,
      * assigning to it the autoincrement primary key (if any is defined).
-     * 
+     *
      * @param Doctrine_Record $record
      * @return void
      */
@@ -937,13 +937,13 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
         if (empty($seq) && !is_array($identifier) &&
             $table->getIdentifierType() != Doctrine_Core::IDENTIFIER_NATURAL) {
             $id = false;
-            if ($record->$identifier == null) { 
+            if ($record->$identifier == null) {
                 if (($driver = strtolower($this->conn->getDriverName())) == 'pgsql') {
                     $seq = $table->getTableName() . '_' . $table->getColumnName($identifier);
                 } elseif ($driver == 'oracle' || $driver == 'mssql') {
                     $seq = $table->getTableName();
                 }
-    
+
                 $id = $this->conn->sequence->lastInsertId($seq);
             } else {
                 $id = $record->$identifier;

--- a/lib/Doctrine/Hydrator/Graph.php
+++ b/lib/Doctrine/Hydrator/Graph.php
@@ -74,15 +74,15 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
         $id = array();
         $idTemplate = array();
 
-        // Initialize 
-        foreach ($this->_queryComponents as $dqlAlias => $data) { 
-            $componentName = $data['table']->getComponentName(); 
-            $instances[$componentName] = $data['table']->getRecordInstance(); 
-            $listeners[$componentName] = $data['table']->getRecordListener(); 
-            $identifierMap[$dqlAlias] = array(); 
-            $prev[$dqlAlias] = null; 
-            $idTemplate[$dqlAlias] = ''; 
-        } 
+        // Initialize
+        foreach ($this->_queryComponents as $dqlAlias => $data) {
+            $componentName = $data['table']->getComponentName();
+            $instances[$componentName] = $data['table']->getRecordInstance();
+            $listeners[$componentName] = $data['table']->getRecordListener();
+            $identifierMap[$dqlAlias] = array();
+            $prev[$dqlAlias] = null;
+            $idTemplate[$dqlAlias] = '';
+        }
         $cache = array();
 
         $result = $this->getElementCollection($rootComponentName);
@@ -109,33 +109,33 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
                 }
             }
             $activeRootIdentifier = null;
-        } else { 
-            $data = $stmt->fetch(Doctrine_Core::FETCH_ASSOC); 
-            if ( ! $data) { 
-                return $result; 
+        } else {
+            $data = $stmt->fetch(Doctrine_Core::FETCH_ASSOC);
+            if ( ! $data) {
+                return $result;
             }
         }
 
         do {
             $table = $this->_queryComponents[$rootAlias]['table'];
-        
+
             if ($table->getConnection()->getAttribute(Doctrine_Core::ATTR_PORTABILITY) & Doctrine_Core::PORTABILITY_RTRIM) {
                 array_map('rtrim', $data);
             }
-        
+
             $id = $idTemplate; // initialize the id-memory
             $nonemptyComponents = array();
             $rowData = $this->_gatherRowData($data, $cache, $id, $nonemptyComponents);
 
-            if ($this->_hydrationMode == Doctrine_Core::HYDRATE_ON_DEMAND)  { 
-                if (is_null($activeRootIdentifier)) { 
-                    // first row for this record 
-                    $activeRootIdentifier = $id[$rootAlias]; 
-                } else if ($activeRootIdentifier != $id[$rootAlias]) { 
-                    // first row for the next record 
-                    $this->_priorRow = $data; 
-                    return $result; 
-                } 
+            if ($this->_hydrationMode == Doctrine_Core::HYDRATE_ON_DEMAND)  {
+                if (is_null($activeRootIdentifier)) {
+                    // first row for this record
+                    $activeRootIdentifier = $id[$rootAlias];
+                } else if ($activeRootIdentifier != $id[$rootAlias]) {
+                    // first row for the next record
+                    $this->_priorRow = $data;
+                    return $result;
+                }
             }
 
             //
@@ -235,9 +235,9 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
                                 }
                                 $prev[$parent][$relationAlias][$element[$field]] = $element;
                             } else {
-                                $prev[$parent][$relationAlias][] = $element; 
+                                $prev[$parent][$relationAlias][] = $element;
                             }
-                            $identifierMap[$path][$id[$parent]][$id[$dqlAlias]] = $this->getLastKey($prev[$parent][$relationAlias]);                            
+                            $identifierMap[$path][$id[$parent]][$id[$dqlAlias]] = $this->getLastKey($prev[$parent][$relationAlias]);
                         }
                         $collection = $prev[$parent][$relationAlias];
                         if ($collection instanceof Doctrine_Collection && $indexField) {
@@ -289,7 +289,7 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
         $rowData = array();
 
         foreach ($data as $key => $value) {
-            // Parse each column name only once. Cache the results. 
+            // Parse each column name only once. Cache the results.
             if ( ! isset($cache[$key])) {
                 // check ignored names. fastest solution for now. if we get more we'll start
                 // to introduce a list.
@@ -360,11 +360,11 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
     abstract public function getElementCollection($component);
 
     abstract public function registerCollection($coll);
- 
+
     abstract public function initRelated(&$record, $name, $keyColumn = null);
- 
+
     abstract public function getNullPointer();
- 
+
     abstract public function getElement(array $data, $component);
 
     abstract public function getLastKey(&$coll);
@@ -395,11 +395,11 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
         if ( ! isset($this->_tables[$component])) {
             $this->_tables[$component] = Doctrine_Core::getTable($component);
         }
-        
+
         if ( ! ($subclasses = $this->_tables[$component]->getOption('subclasses'))) {
             return $component;
         }
-        
+
         $matchedComponents = array($component);
         foreach ($subclasses as $subclass) {
             $table = Doctrine_Core::getTable($subclass);
@@ -416,22 +416,23 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
                     $matchedComponents[] = $table->getComponentName();
                 }
             } else {
-                list($key, $value) = each($inheritanceMap);
-                $key = $this->_tables[$component]->getFieldName($key);
-                if ( ! isset($data[$key]) || $data[$key] != $value) {
-                    continue;
-                } else {
-                    $matchedComponents[] = $table->getComponentName();
+                foreach ($inheritanceMap as $key => $value) {
+                    $key = $this->_tables[$component]->getFieldName($key);
+                    if ( ! isset($data[$key]) || $data[$key] != $value) {
+                        continue;
+                    } else {
+                        $matchedComponents[] = $table->getComponentName();
+                    }
                 }
             }
         }
-        
+
         $matchedComponent = $matchedComponents[count($matchedComponents)-1];
-        
+
         if ( ! isset($this->_tables[$matchedComponent])) {
             $this->_tables[$matchedComponent] = Doctrine_Core::getTable($matchedComponent);
         }
-        
+
         return $matchedComponent;
     }
 }


### PR DESCRIPTION
The `each` array function was deprecated under PHP7 and removed altogether under PHP8.

This change was made following a bunch of failed tests throwing: `Error: Call to undefined function each()`