### PR TITLE
Added rootAlias property

### DIFF
--- a/lib/Doctrine/Hydrator/Graph.php
+++ b/lib/Doctrine/Hydrator/Graph.php
@@ -36,6 +36,7 @@
 abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
 {
     protected $_tables = array();
+    protected $_rootAlias = '';
 
     /**
      * Gets the custom field used for indexing for the specified component alias.


### PR DESCRIPTION
Fixes:
```
Creation of dynamic property Doctrine_Hydrator_ArrayDriver::$_rootAlias is deprecated in doctrine1/lib/Doctrine/Hydrator/Graph.php on line 56
```
