### PR TITLE
fix: log failing query for parameterised statements (#12)

### DIFF
--- a/lib/Doctrine/Connection/Statement.php
+++ b/lib/Doctrine/Connection/Statement.php
@@ -283,7 +283,10 @@ class Doctrine_Connection_Statement implements Doctrine_Adapter_Statement_Interf
         } catch (Doctrine_Adapter_Exception $e) {
         }
 
-        $this->_conn->rethrowException($e, $this);
+        // Pass the prepared SQL so rethrowException() appends the failing query
+        // to the message. Placeholders only (no bound values) to avoid logging
+        // sensitive parameter data.
+        $this->_conn->rethrowException($e, $this, $this->getQuery());
 
         return false;
     }


### PR DESCRIPTION
## What

Log the failing SQL for **parameterised** queries so database errors are traceable to a table/column.

Fixes #12.

## Why

`Doctrine_Connection::rethrowException()` already appends `Failing Query: "..."` to the exception message when given a query, and the non-parameterised paths pass it. But `Doctrine_Connection_Statement::execute()` — the path taken by virtually every query with bound parameters — called `rethrowException($e, $this)` without the query. So errors like the one below were logged with no SQL, no table, no column:

```
SQLSTATE[22003]: Numeric value out of range: 7 ERROR: value "004434700000226" is out of range for type integer
CONTEXT: unnamed portal parameter $2 = '...'
```

## Change

```php
// lib/Doctrine/Connection/Statement.php
$this->_conn->rethrowException($e, $this, $this->getQuery());
```

`getQuery()` returns the prepared statement's `queryString`, which contains only placeholders (`$1`, `$2`) — **no bound values are logged**, so there is no PCI/PII exposure.

After this change the message gains the existing suffix, e.g.:

```
... out of range for type integer ... . Failing Query: "SELECT ... WHERE t.some_int_col = $2 ..."
```

## Relationship to PR #11

Supersedes #11 (KAI-2155). That approach parsed the query to log truncated parameter **values** (a PCI/PII risk) and only fired on `too long`/`truncated` errors — not the `22003` numeric-out-of-range case. This PR is the minimal, query-only fix.
